### PR TITLE
Develop

### DIFF
--- a/wp-content/plugins/aralsf-main/acf-json/group_674b4e8c84052.json
+++ b/wp-content/plugins/aralsf-main/acf-json/group_674b4e8c84052.json
@@ -61,26 +61,6 @@
             "ui_off_text": ""
         },
         {
-            "key": "field_674b50f4a5310",
-            "label": "Display Pagination",
-            "name": "pagination",
-            "aria-label": "",
-            "type": "true_false",
-            "instructions": "",
-            "required": 0,
-            "conditional_logic": 0,
-            "wrapper": {
-                "width": "",
-                "class": "",
-                "id": ""
-            },
-            "message": "Yes \/ No",
-            "default_value": 1,
-            "ui": 0,
-            "ui_on_text": "",
-            "ui_off_text": ""
-        },
-        {
             "key": "field_674b4fa3d5678",
             "label": "Slide Speed",
             "name": "slide_speed",
@@ -120,5 +100,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1732991190
+    "modified": 1732992539
 }

--- a/wp-content/plugins/aralsf-main/aralsf-main.php
+++ b/wp-content/plugins/aralsf-main/aralsf-main.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: AralSf Core
  * Description: Core functionalities for the AralSf site.
- * Version: 1.0.6
+ * Version: 1.0.7
  * Author: Garegin Hakobyan
  * Author URI: https://hakobyan.vercel.app/
  */

--- a/wp-content/themes/aral-distribution/style.css
+++ b/wp-content/themes/aral-distribution/style.css
@@ -7,7 +7,7 @@ Description: Exclusive WordPress template for Aral Distribution.
 Requires at least: 5.3
 Tested up to: 6.6
 Requires PHP: 7.4
-Version: 1.0.22
+Version: 1.0.23
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: araldistribution

--- a/wp-content/themes/aral-distribution/template-parts/blocks/categories-slider/template.php
+++ b/wp-content/themes/aral-distribution/template-parts/blocks/categories-slider/template.php
@@ -38,7 +38,6 @@ $categories = get_terms( array(
 
 $slide_loop         = get_field( 'slide_loop' ) ? 'true' : 'false';
 $autoplay           = get_field( 'autoplay' ) ? 'true' : 'false';
-$display_pagination = get_field( 'display_pagination' );
 $slide_speed        = intval( get_field( 'slide_speed' ) ) ? : 2000;
 ?>
 <section
@@ -98,12 +97,11 @@ $slide_speed        = intval( get_field( 'slide_speed' ) ) ? : 2000;
                     </div><!-- .swiper-slide -->
 				<?php endforeach; ?>
             </div>
-			
-			<?php if ( $display_pagination ): ?>
-                <div class="categories-pagination__wrap bg-yellow-500 absolute bottom-4 left-1/2 -translate-x-1/2 px-4 py-1 rounded-full z-10">
-                    <div class="categories-pagination"></div>
-                </div>
-			<?php endif; ?>
+
+            <div class="categories-pagination__wrap bg-yellow-500 absolute bottom-4 left-1/2 -translate-x-1/2 px-4 py-1 rounded-full z-10">
+                <div class="categories-pagination"></div>
+            </div>
+
         </div><!-- .categories-carousel -->
 	<?php endif; ?>
 </section>


### PR DESCRIPTION
This pull request includes changes to the `AralSf` WordPress plugin and the `aral-distribution` WordPress theme. The most significant changes involve the removal of the pagination field and its associated logic, as well as version updates for both the plugin and the theme.

Changes related to pagination:

* Removed the `Display Pagination` field from the `acf-json` configuration file.
* Removed the `$display_pagination` variable and its associated conditional logic from the `categories-slider` template. [[1]](diffhunk://#diff-b6ea54f2f0779cb364725b45467373bcc8ef47e2a5d01908851c17c4e060f858L41) [[2]](diffhunk://#diff-b6ea54f2f0779cb364725b45467373bcc8ef47e2a5d01908851c17c4e060f858L102-R104)

Version updates:

* Updated the plugin version from `1.0.6` to `1.0.7` in `aralsf-main.php`.
* Updated the theme version from `1.0.22` to `1.0.23` in `style.css`.

Other changes:

* Updated the `modified` timestamp in the `acf-json` configuration file.